### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=Marc Symonds
 maintainer=Marc Symonds <marc@marcsymonds.me>
 sentence=Arduino library for reading and writing the time to a DS1307 RTC.
 paragraph=Requires the Wire library.
-category=Time
+category=Timing
 url=
 architectures=*


### PR DESCRIPTION
The previous category value caused the warning:
```
WARNING: Category 'Time' in library DS1307 is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format